### PR TITLE
Added .coveragerc to control coverage report, updated pylint config file, workflow edits

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,7 @@
 # .coveragerc
 
 [run]
-include = cogs/*,conftest.py,test/*,db.py,
-omit = *bot.py,*setup.py
+include = cogs/*,test/*,conftest.py,db.py,setup.py,bot.py
 
 [report]
-omit = *bot.py,*setup.py
+omit = setup.py,bot.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+# .coveragerc
+
+[run]
+include = cogs/*,conftest.py,test/*,db.py,
+omit = *bot.py,*setup.py
+
+[report]
+omit = *bot.py,*setup.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Test with pytest
       run: pytest
     - name: Generate coverage
-      run:  pytest --cov=./ --cov-report=xml
+      run:  pytest --cov-config=.coveragerc --cov --cov-report=xml
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v2
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,9 +25,3 @@ jobs:
         EOF
     - name: Test with pytest
       run: pytest
-    - name: Generate coverage
-      run:  pytest --cov=./ --cov-report=xml
-    - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
-      with:
-        fail_ci_if_error: true

--- a/.pylintrc
+++ b/.pylintrc
@@ -169,7 +169,11 @@ disable=print-statement,
         E0401,
         C0413,
         R0801,
-        R0201
+        R0201,
+        C0301, # Line too long (127/120) (line-too-long)
+        C0411, # (wrong-import-order)
+        W0611, # Unused join imported from os.path (unused-import)
+        C0412  # Imports from package discord are not grouped (ungrouped-imports)
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
### Summary

<!-- Summarize this PR here! -->

Added `.coveragerc` config file to control coverage report
Removed setup.py from coverage report

Updated `.pylintrc` config file: disabled some checks
workflow edits


### New Files

Added `.coveragerc` to control coverage report. 

### Deleted Files

None

### Changed Files

`.pylintrc`
```
Disabled some checks:
C0301 (line-too-long)
C0411 (wrong-import-order)
W0611 (unused-import)
C0412 (ungrouped-imports)
```

`pytest_with_cov.yml`: Removed codecov reporting and renamed as `pytest.yml`

`main.yml`:  Updated to use `.coveragerc` config file

### Checklist

<!-- If your changes don't affect working code, delete all checkboxes and write N/A -->

N/A

----

#### Closing Issues

Resolves #39 

#### Bugs, Notes

<!-- Need help with something? Use the 'Help Wanted' tag and write a short summary of what the problem is --> 
<!-- If there's a bug you can't fix, make an issue and use the 'Help wanted' and 'bug' tags! --> 

#### Contributors

@snapcat 
