### PR TITLE
Q&A Commands

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -166,6 +166,7 @@ disable=print-statement,
         R0912, # Too many branches (17/12) (too-many-branches)
         R0915, # Too many statements (85/50) (too-many-statements)
         R0903, # Too few public methods (0/2) (too-few-public-methods)
+        R0904, # Too many public methods (24/20) (too-many-public-methods)
         E0401,
         C0413,
         R0801,
@@ -173,7 +174,8 @@ disable=print-statement,
         C0301, # Line too long (127/120) (line-too-long)
         C0411, # (wrong-import-order)
         W0611, # Unused join imported from os.path (unused-import)
-        C0412  # Imports from package discord are not grouped (ungrouped-imports)
+        C0412, # Imports from package discord are not grouped (ungrouped-imports)
+        C0302 # Too many lines in module (1072/1000) (too-many-lines)
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -31,6 +31,16 @@ class Qanda(commands.Cog):
             await ctx.message.delete()
             return
 
+        if not qs or qs.isspace():
+            await ctx.author.send("Please enter a valid question.")
+            await ctx.message.delete()
+            return
+
+        if len(qs) <= 2:
+            await ctx.author.send('Question too short.')
+            await ctx.message.delete()
+            return
+
         # get author
         if anonymous == '':
             author = ctx.message.author.id
@@ -94,7 +104,7 @@ class Qanda(commands.Cog):
     @commands.command(name='answer',
                       help='Answer question. Please put answer text in quotes. Add *anonymous* or *anon* if desired.'
                            'EX: $answer 1 /"Oct 12/" anonymous')
-    async def answer(self, ctx, num, ans, anonymous=''):
+    async def answer(self, ctx, num, ans: str, anonymous=''):
         ''' answer the specific question '''
         # make sure to check that this is actually being asked in the Q&A channel
         if not ctx.channel.name == 'q-and-a':
@@ -102,16 +112,15 @@ class Qanda(commands.Cog):
             await ctx.message.delete()
             return
 
-        # to stop SQL from freezing. Only allows valid numbers.
-        if not re.match(r'^([1-9]\d*|0)$', num):
-            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+        if not ans or ans.isspace():
+            await ctx.author.send("Please enter a valid answer.")
             await ctx.message.delete()
             return
 
-        #if not isinstance(ans, str):
-            #await ctx.author.send('Please include a valid answer. EX: $answer 1 /"Oct 12/" anonymous')
-           # await ctx.message.delete()
-           # return
+#        if len(ans) == 0:
+#            await ctx.author.send('Answer too short.')
+#            await ctx.message.delete()
+#            return
 
         # get author
         if anonymous == '':
@@ -122,6 +131,12 @@ class Qanda(commands.Cog):
             author = None
         else:
             await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
+            await ctx.message.delete()
+            return
+
+        # to stop SQL from freezing. Only allows valid numbers.
+        if not re.match(r'^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
             await ctx.message.delete()
             return
 

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -253,7 +253,7 @@ class Qanda(commands.Cog):
         try:
             message = await ctx.fetch_message(q[3])
         except NotFound:
-            nf_str = f"Question {num} not found in channel. It may have been deleted."
+            nf_str = f"Q{num} is a ghost!"
             await ctx.author.send(nf_str)
             # delete user msg
             await ctx.message.delete()

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -122,7 +122,7 @@ class Qanda(commands.Cog):
             return
 
         # check if question number exists
-        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+        q = db.query('SELECT number, question, author_id, msg_id, is_ghost FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
             await ctx.author.send('No such question with the number: ' + str(num))
@@ -131,11 +131,17 @@ class Qanda(commands.Cog):
             return
         q = q[0]
 
+        # if is_ghost is true:
+        if q[4]:
+            await ctx.author.send("You can't answer a ghost!")
+            await ctx.message.delete()
+            return
+
         # check if message exists
         try:
             message = await ctx.fetch_message(q[3])
         except NotFound:
-            nf_str = f"Question {num} not found. It may have been deleted."
+            nf_str = f"Question {num} not found. It's a zombie!"
             await ctx.author.send(nf_str)
             # delete user msg
             await ctx.message.delete()
@@ -166,7 +172,7 @@ class Qanda(commands.Cog):
         try:
             await message.edit(content=new_answer)
         except NotFound:
-            nf_str = f"Question {num} not found. It may have been deleted."
+            nf_str = f"Question {num} not found. It's a zombie!"
             await ctx.author.send(nf_str)
             #await ctx.author.send('Invalid question number: ' + str(num))
 
@@ -224,7 +230,7 @@ class Qanda(commands.Cog):
             return
 
         # check if question number exists
-        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+        q = db.query('SELECT number, question, author_id, msg_id, is_ghost FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
             await ctx.author.send('No such question with the number: ' + str(num))
@@ -241,22 +247,32 @@ class Qanda(commands.Cog):
             'SELECT * FROM answers WHERE guild_id = %s AND q_number = %s',
             (ctx.guild.id, num)
         )
+
+        rd = len(rows_deleted)
+
         # Delete all answers for question
         db.query('DELETE FROM answers WHERE guild_id = %s AND q_number = %s',
                 (ctx.guild.id, num))
 
-        if len(rows_deleted) == 0:
+        if rd == 0:
             await ctx.author.send(
                 f"No answers exist for Q{num}")
         else:
             await ctx.author.send(
-                f"deleted {len(rows_deleted)} answers for Q{num}")
+                f"deleted {rd} answers for Q{num}")
+
+        # if it's a ghost, return.
+        if q[4]:
+            ghost = f"Q{num} is a ghost!"
+            await ctx.author.send(ghost)
+            await ctx.message.delete()
+            return
 
         # check if message exists on the channel. If it does, restore the question!
         try:
             message = await ctx.fetch_message(q[3])
         except NotFound:
-            nf_str = f"Q{num} is a ghost!"
+            nf_str = f"Q{num} is a zombie!"
             await ctx.author.send(nf_str)
             # delete user msg
             await ctx.message.delete()
@@ -312,7 +328,7 @@ class Qanda(commands.Cog):
             return
 
         # check if question number exists
-        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+        q = db.query('SELECT number, question, author_id, msg_id, is_ghost FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
             await ctx.author.send('No such question with the number: ' + str(num))
@@ -322,11 +338,17 @@ class Qanda(commands.Cog):
 
         q = q[0]
 
+        # if the question is a ghost, return.
+        if q[4]:
+            nf_str = f"Q{q[0]} is a ghost!"
+            await ctx.author.send(nf_str)
+            await ctx.message.delete()
+            return
         # check if message exists on channel
         try:
             await ctx.fetch_message(q[3])
         except NotFound:
-            nf_str = f"Question {num} not found. It may have been deleted."
+            nf_str = f"Question {num} not found. It's a zombie!"
             await ctx.author.send(nf_str)
             # delete user msg
             await ctx.message.delete()
@@ -373,10 +395,7 @@ class Qanda(commands.Cog):
                 '(Example: $getAnswersFor 1)')
         else:
             await ctx.author.send(error)
-        #try:
         await ctx.message.delete()
-        #except NotFound:
-        #    pass
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: archiveQA
@@ -397,7 +416,7 @@ class Qanda(commands.Cog):
             return
 
         # get questions
-        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s ORDER BY number ASC',
+        q = db.query('SELECT number, question, author_id, msg_id, is_ghost FROM questions WHERE guild_id = %s ORDER BY number ASC',
                      (ctx.guild.id,))
         if len(q) == 0:
             await ctx.author.send('No questions found in database.')
@@ -405,16 +424,24 @@ class Qanda(commands.Cog):
             await ctx.message.delete()
             return
 
-        for number, question, author_id, msg_id in q:
+        for number, question, author_id, msg_id, is_ghost in q:
+
+            # prevent receiving any hidden questions.
+            if is_ghost:
+                nf_str = f"Q{number} is a ghost!"
+                await ctx.author.send(nf_str)
+                #go to next question
+                continue
 
             # prevent receiving any deleted questions.
             try:
                 await ctx.fetch_message(msg_id)
             except NotFound:
-                nf_str = f"Q{number} is a ghost!"
-                await ctx.author.send(nf_str)
-                #go to next question
-                continue
+                if not is_ghost:
+                    nf_str = f"Q{number} was deleted. It's a zombie!"
+                    await ctx.author.send(nf_str)
+                    #go to next question
+                    continue
 
             q_author_str = 'anonymous' if author_id is None else (await self.bot.fetch_user(author_id)).name
             qstr = f"Q{number}: {question} by {q_author_str}\n"
@@ -447,11 +474,7 @@ class Qanda(commands.Cog):
     # -----------------------------------------------------------------------------------------------------------------
     @archiveQA.error
     async def archiveqa_error(self, ctx, error):
-        if isinstance(error, commands.MissingRequiredArgument):
-            await ctx.author.send(
-                'archiveQA doesn\'t need any arguments. Just use $archiveQA')
-        else:
-            await ctx.author.send(error)
+        await ctx.author.send(error)
         await ctx.message.delete()
 
 
@@ -464,11 +487,13 @@ class Qanda(commands.Cog):
     #       -
     # -----------------------------------------------------------------------------------------------------------------
     @commands.has_role('Instructor')
-    @commands.command(name='deleteAllQA', help='(PLACEHOLDER NAME) Delete all questions and answers from the database and channel.\n'
-                                       'EX: $deleteAllQA\n'
-                                       'THIS COMMAND IS IRREVERSIBLE.\n'
-                                       'BE SURE TO ARCHIVE ALL QUESTIONS BEFORE DELETION. ($archiveQA)'
-                                       )
+    @commands.command(name='deleteAllQA', help='Delete all questions and answers from the database and channel.\n'
+                                'EX: $deleteAllQA\n'
+                                'THIS COMMAND IS IRREVERSIBLE.\n'
+                                'BE SURE TO ARCHIVE ALL QUESTIONS BEFORE DELETION.\n'
+                                'To archive, use the $unearthZombies command followed by $allChannelGhosts,'
+                                ' and then use $archiveQA.'
+                                )
     async def deleteAllQAs(self, ctx):
 
         # make sure to check that this is actually being used in the Q&A channel
@@ -478,32 +503,41 @@ class Qanda(commands.Cog):
             return
 
         # get questions
-        q = db.query('SELECT msg_id FROM questions WHERE guild_id = %s',
+        q = db.query('SELECT msg_id, is_ghost FROM questions WHERE guild_id = %s',
                      (ctx.guild.id,))
-        if len(q) == 0:
+
+        numqs = len(q)
+        if numqs == 0:
             await ctx.author.send('No questions found in database.')
             return
 
-        #Questions that were previously deleted on the channel but not in the database.
-        ghostqs = 0
-        # delete questions in channel
-        for msg_id in q:
-            mid = msg_id[0]
+        # Zombies are questions that were manually deleted from the channel. They need to be
+        # assigned new message IDs in order to be restored--that is, they need to be reposted.
+        # Ghosts are questions that were deleted (or hidden) with the deleteQuestion command.
+        # Because their message IDs remain the same, their contents can just be unhidden.
+
+        # track ghosts and zombies, and delete messages in the channel
+        zombies = 0
+        ghosts = 0
+        for msg_id, is_ghost in q:
+            if is_ghost:
+                ghosts += 1
             try:
-                message = await ctx.fetch_message(mid)
+                message = await ctx.fetch_message(msg_id)
             except NotFound:
-                ghostqs += 1
+                if not is_ghost:
+                    zombies += 1
                 continue
             else:
                 await message.delete()
 
-        # count deleted questions
-        qs_deleted = db.query(
-            'SELECT * FROM questions WHERE guild_id = %s',
-            (ctx.guild.id,)
-        )
+        # count ghosts
+        #spooks = db.query(
+        #    'SELECT * FROM questions WHERE guild_id = %s AND is_ghost IS TRUE',
+        #    (ctx.guild.id,)
+        #)
 
-        numqs = len(qs_deleted)
+        #spooky = len(spooks)
 
         # Delete all questions
         db.query('DELETE FROM questions WHERE guild_id = %s',
@@ -513,7 +547,7 @@ class Qanda(commands.Cog):
         db.query('DELETE FROM answers WHERE guild_id = %s',
                 (ctx.guild.id,))
 
-        report = f"Deleted {numqs} questions from the database, including {ghostqs} ghost questions."
+        report = f"Deleted {numqs} questions from the database, including {zombies} zombies and {ghosts} ghosts."
         await ctx.author.send(report)
 
         # delete user msg
@@ -530,17 +564,13 @@ class Qanda(commands.Cog):
     # -----------------------------------------------------------------------------------------------------------------
     @deleteAllQAs.error
     async def deleteAllQAs_error(self, ctx, error):
-        if isinstance(error, commands.MissingRequiredArgument):
-            await ctx.author.send(
-                'deleteAllQA doesn\'t need any arguments. Just use $deleteAllQA')
-        else:
-            await ctx.author.send(error)
+        await ctx.author.send(error)
         await ctx.message.delete()
 
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: deleteOneQuestion
-    #    Description: Delete one question and all of its answers. Instructor only.
+    #    Description: Delete one question but leave answers untouched. Instructor only.
     #    Inputs:
     #       - ctx: context of the command
     #       - num: number of the question to delete
@@ -548,8 +578,8 @@ class Qanda(commands.Cog):
     #       -
     # -----------------------------------------------------------------------------------------------------------------
     @commands.has_role('Instructor')
-    @commands.command(name='deleteQuestion', help='Delete one question and all its answers.'
-                                    ' Leaves database ghosts. (RESURRECTION COMING SOON)\n'
+    @commands.command(name='deleteQuestion', help='Delete (hide) one question but leave answers untouched.'
+                                    ' Leaves database ghosts.\n'
                                     'EX: $deleteQuestion QUESTION_NUMBER\n'
                                     )
     async def deleteOneQuestion(self, ctx, num):
@@ -581,16 +611,21 @@ class Qanda(commands.Cog):
         if not q[2]:
             db.query('UPDATE questions SET is_ghost = NOT is_ghost WHERE guild_id = %s AND number = %s',
             (ctx.guild.id, num))
+        else:
+            sendme = f"Q{q[0]} is already a ghost!"
+            await ctx.author.send(sendme)
+            return
 
-        # check if message exists on channel
+        # check if message exists on channel.
         try:
             msg = await ctx.fetch_message(q[1])
         except NotFound:
-            nf_str = f"Q{q[0]} is already a ghost!"
+            nf_str = f"Q{q[0]} was not found in channel. To restore it, use: $reviveGhost {q[0]}"
             await ctx.author.send(nf_str)
         else:
-            await msg.delete()
-            haunt = f"Q{q[0]} is now a ghost. To see ghost handling options, use the $help command."
+            cstr = f"Q{q[0]}: _hidden_"
+            await msg.edit(content=cstr)
+            haunt = f"Q{q[0]} is now a ghost. To restore it, use: $reviveGhost {q[0]}"
             await ctx.author.send(haunt)
 
         await ctx.message.delete()
@@ -613,6 +648,381 @@ class Qanda(commands.Cog):
         else:
             await ctx.author.send(error)
         await ctx.message.delete()
+
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: channelOneGhost
+    #    Description: Gets a specific ghost question. Instructor only.
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - num: question number
+    #    Outputs:
+    #       - All answers for a ghost question, if any
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
+    @commands.command(name='channelGhost', help='Gets a specific ghost (question deleted with command) and all its answers.\n'
+                                       'EX: $channelGhost 1')
+    async def channelOneGhost(self, ctx, num):
+
+        # make sure to check that this is actually being used in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+
+        # to stop SQL from screaming. Only allows valid numbers.
+        if not re.match(r'^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $channelGhost 1')
+            await ctx.message.delete()
+            return
+
+        # check if question number exists
+        q = db.query('SELECT number, question, author_id, is_ghost FROM questions WHERE guild_id = %s AND number = %s',
+                     (ctx.guild.id, num))
+        if len(q) == 0:
+            await ctx.author.send('No such question with the number: ' + str(num))
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        q = q[0]
+
+        if not q[3]:
+            await ctx.author.send('This question is not a ghost. Fetching anyway. . .')
+
+        # retrieve question msg
+        q_author_str = 'anonymous' if q[2] is None else (await self.bot.fetch_user(q[2])).name
+        qstr = f"Q{q[0]}: {q[1]} by {q_author_str}\n"
+
+        # get all answers for question and add to msg
+        answers = db.query('SELECT answer, author_id, author_role FROM answers WHERE guild_id = %s AND q_number = %s',
+                           (ctx.guild.id, num))
+
+        # if there are no answers, return
+        if len(answers) == 0:
+            qstr += f"No answers for Q{q[0]}\n"
+            await ctx.author.send(qstr)
+            await ctx.message.delete()
+            return
+
+        for answer, author, role in answers:
+            a_author = 'anonymous' if author is None else (await self.bot.fetch_user(author)).name
+            qstr += f"{a_author} ({role}) Ans: {answer}\n"
+
+        # send the question and answers to user
+        await ctx.author.send(qstr)
+        await ctx.message.delete()
+
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: channelOneGhost_error(self, ctx, error)
+    #    Description: prints error message for channelGhost command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @channelOneGhost.error
+    async def channelOneGhost_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.author.send(
+                'To use the channelGhost command, do: $channelGhost QUESTION_NUMBER\n '
+                '(Example: $channelGhost 1)')
+        else:
+            await ctx.author.send(error)
+        await ctx.message.delete()
+
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: channelGhostQs
+    #    Description: Get the questions that are in the database but not in the channel. Instructor only.
+    #    Inputs:
+    #       - ctx: context of the command
+    #    Outputs:
+    #       -
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
+    @commands.command(name='allChannelGhosts', help='Get all the questions that are in the database but '
+                                    'not in the channel. Does not detect zombies.\n'
+                                    'EX: $allChannelGhosts\n'
+                                    'To detect zombies and convert them to ghosts, use $unearthZombies'
+                                    )
+    async def channelGhostQs(self, ctx):
+
+        # make sure to check that this is actually being used in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+
+         # get questions
+        q = db.query('SELECT number, question, author_id FROM questions WHERE guild_id = %s AND is_ghost IS TRUE ORDER BY number ASC',
+                     (ctx.guild.id,))
+        if len(q) == 0:
+            await ctx.author.send('No ghosts found in database.')
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        for number, question, author_id in q:
+
+            q_author_str = 'anonymous' if author_id is None else (await self.bot.fetch_user(author_id)).name
+            qstr = f"Q{number}: {question} by {q_author_str}\n"
+
+            # get all answers for question and add to msg
+            answers = db.query('SELECT answer, author_id, author_role FROM answers WHERE guild_id = %s AND q_number = %s',
+                           (ctx.guild.id, number))
+
+            if len(answers) == 0:
+                qstr += f"No answers for Q{number}\n"
+            else:
+                for answer, author, role in answers:
+                    a_author = 'anonymous' if author is None else (await self.bot.fetch_user(author)).name
+                    qstr += f"{a_author} ({role}) Ans: {answer}\n"
+
+            # send the question and answers to user
+            await ctx.author.send(qstr)
+
+        # delete msg
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: channelGhostQs_error(self, ctx, error)
+    #    Description: prints error message for allChannelGhosts command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @channelGhostQs.error
+    async def channelGhostQs_error(self, ctx, error):
+        await ctx.author.send(error)
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: unearthZombieQs
+    #    Description: Assign ghost status to all manually deleted questions in case there is a
+    #                 need to restore them. Instructor only.
+    #    Inputs:
+    #       - ctx: context of the command
+    #    Outputs:
+    #       -
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
+    @commands.command(name='unearthZombies', help='Assign ghost status to all manually deleted questions '
+                                    'in case there is a need to restore them.\n'
+                                    'EX: $unearthZombies\n'
+                                    )
+    async def unearthZombieQs(self, ctx):
+
+        # make sure to check that this is actually being used in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+
+        # get questions
+        q = db.query('SELECT number, msg_id FROM questions WHERE guild_id = %s AND is_ghost IS FALSE',
+                     (ctx.guild.id,))
+        if len(q) == 0:
+            await ctx.author.send('No zombies detected.')
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        zombies = 0
+        for number, msg_id in q:
+            try:
+                await ctx.fetch_message(msg_id)
+            except NotFound:
+                zombies += 1
+                db.query('UPDATE questions SET is_ghost = NOT is_ghost WHERE guild_id = %s AND number = %s',
+                (ctx.guild.id, number))
+
+        if zombies == 0:
+            await ctx.author.send("No zombies detected.")
+        else:
+            zomstr = f"Found {zombies} zombies and assigned them ghost status.\n"
+            zomstr += "To view them, use: $allChannelGhosts\n"
+            zomstr += "To restore a question, use: $reviveGhost QUESTION_NUMBER"
+            await ctx.author.send(zomstr)
+
+        # delete msg
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: unearthZombieQss_error(self, ctx, error)
+    #    Description: prints error message for unearthZombies command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @unearthZombieQs.error
+    async def unearthZombieQs_error(self, ctx, error):
+        await ctx.author.send(error)
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: restoreGhost
+    #    Description: Restores a ghost or deleted question to the channel. Instructor only.
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - num: question number
+    #    Outputs:
+    #       - All answers for a ghost question, if any
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
+    @commands.command(name='reviveGhost', help='Restores a ghost or deleted/hidden question to the channel.\n'
+                                       'EX: $reviveGhost 1')
+    async def restoreGhost(self, ctx, num):
+
+        # make sure to check that this is actually being used in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+
+        # to stop SQL from screaming. Only allows valid numbers.
+        if not re.match(r'^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $reviveGhost 1')
+            await ctx.message.delete()
+            return
+
+        # check if question number exists
+        q = db.query('SELECT number, question, author_id, msg_id, is_ghost FROM questions WHERE guild_id = %s AND number = %s',
+                     (ctx.guild.id, num))
+        if len(q) == 0:
+            await ctx.author.send('No such question with the number: ' + str(num))
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        q = q[0]
+
+        # retrieve question msg
+        q_author_str = 'anonymous' if q[2] is None else (await self.bot.fetch_user(q[2])).name
+        qstr = f"Q{q[0]}: {q[1]} by {q_author_str}\n"
+
+        # get all answers for question and add to msg
+        answers = db.query('SELECT answer, author_id, author_role FROM answers WHERE guild_id = %s AND q_number = %s',
+                           (ctx.guild.id, num))
+
+        # if there are answers, restore them
+        if len(answers) != 0:
+            for answer, author, role in answers:
+                a_author = 'anonymous' if author is None else (await self.bot.fetch_user(author)).name
+                qstr += f"{a_author} ({role}) Ans: {answer}\n"
+
+        try:
+            msg = await ctx.fetch_message(q[3])
+        except NotFound:
+            # if the question was manually deleted, post it again (with all its answers)!
+            message = await ctx.send(qstr)
+            db.query('UPDATE questions SET msg_id = %s WHERE guild_id = %s AND number = %s',
+            (message.id, ctx.guild.id, num))
+        else:
+            # restore the question
+            await msg.edit(content=qstr)
+
+        # if is_ghost is true, set to false
+        if q[4]:
+            db.query('UPDATE questions SET is_ghost = NOT is_ghost WHERE guild_id = %s AND number = %s',
+            (ctx.guild.id, num))
+
+
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: restoreGhost_error(self, ctx, error)
+    #    Description: prints error message for reviveGhost command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @restoreGhost.error
+    async def restoreGhost_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.author.send(
+                'To use the reviveGhost command, do: $reviveGhost QUESTION_NUMBER\n '
+                '(Example: $reviveGhost 1)')
+        else:
+            await ctx.author.send(error)
+        await ctx.message.delete()
+
+
+
+
+
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: countGhosts
+    #    Description: Counts the number of ghost and zombie questions in the channel. Just for fun, but may be useful
+    #    Inputs:
+    #       - ctx: context of the command
+    #    Outputs:
+    #       - The number of ghost questions
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.command(name='spooky', help='Is this channel haunted?\n'
+                                       'EX: $spooky')
+    async def countGhosts(self, ctx):
+
+        # make sure to check that this is actually being used in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+
+        q = db.query('SELECT msg_id, is_ghost FROM questions WHERE guild_id = %s',
+                     (ctx.guild.id,))
+        # if database is empty
+        if len(q) == 0:
+            await ctx.author.send("This channel isn't haunted.")
+            await ctx.message.delete()
+            return
+
+        zombies = 0
+        ghosts = 0
+        for msg_id, is_ghost in q:
+            # if it is a ghost, it doesn't matter if it isn't found.
+            if is_ghost:
+                ghosts += 1
+                continue
+            # if the message isn't found and it isn't a ghost, it's a zombie.
+            try:
+                await ctx.fetch_message(msg_id)
+            except NotFound:
+                zombies += 1
+
+        if zombies == 0 and ghosts == 0:
+            await ctx.author.send("This channel isn't haunted.")
+            await ctx.message.delete()
+            return
+
+        spookstr = f"This channel is haunted by {ghosts} ghosts and {zombies} zombies."
+        await ctx.author.send(spookstr)
+        await ctx.message.delete()
+
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: countGhosts_error(self, ctx, error)
+    #    Description: prints error message for spooky command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @countGhosts.error
+    async def countGhosts_error(self, ctx, error):
+        await ctx.author.send(error)
+        await ctx.message.delete()
+
 
 def setup(bot):
     n = Qanda(bot)

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -21,7 +21,7 @@ class Qanda(commands.Cog):
     #    Outputs:
     #       - User question in new post
     # -----------------------------------------------------------------------------------------------------------------
-    @commands.command(name='ask', help='Ask question. Please put question text in quotes. Add *anonymous* if desired.'
+    @commands.command(name='ask', help='Ask question. Please put question text in quotes. Add *anonymous* or *anon* if desired.'
                                        'EX: $ask /"When is the exam?/" anonymous')
     async def askQuestion(self, ctx, qs: str, anonymous=''):
 
@@ -36,8 +36,10 @@ class Qanda(commands.Cog):
             author = ctx.message.author.id
         elif anonymous == 'anonymous':
             author = None
+        elif anonymous == 'anon':
+            author = None
         else:
-            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
             await ctx.message.delete()
             return
 
@@ -90,7 +92,7 @@ class Qanda(commands.Cog):
     #      - User answer added to question post
     # -----------------------------------------------------------------------------------------------------------------
     @commands.command(name='answer',
-                      help='Answer question. Please put answer text in quotes. Add *anonymous* if desired.'
+                      help='Answer question. Please put answer text in quotes. Add *anonymous* or *anon* if desired.'
                            'EX: $answer 1 /"Oct 12/" anonymous')
     async def answer(self, ctx, num, ans, anonymous=''):
         ''' answer the specific question '''
@@ -116,8 +118,10 @@ class Qanda(commands.Cog):
             author = ctx.message.author.id
         elif anonymous == 'anonymous':
             author = None
+        elif anonymous == 'anon':
+            author = None
         else:
-            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
             await ctx.message.delete()
             return
 

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -125,7 +125,7 @@ class Qanda(commands.Cog):
         q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            await ctx.author.send('No such question with the number: ' + str(num))
             # delete user msg
             await ctx.message.delete()
             return
@@ -135,7 +135,8 @@ class Qanda(commands.Cog):
         try:
             message = await ctx.fetch_message(q[3])
         except NotFound:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            nf_str = f"Question {num} not found. It may have been deleted."
+            await ctx.author.send(nf_str)
             # delete user msg
             await ctx.message.delete()
             return
@@ -165,7 +166,9 @@ class Qanda(commands.Cog):
         try:
             await message.edit(content=new_answer)
         except NotFound:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            nf_str = f"Question {num} not found. It may have been deleted."
+            await ctx.author.send(nf_str)
+            #await ctx.author.send('Invalid question number: ' + str(num))
 
         # delete user msg
         await ctx.message.delete()
@@ -224,7 +227,7 @@ class Qanda(commands.Cog):
         q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            await ctx.author.send('No such question with the number: ' + str(num))
             # delete user msg
             await ctx.message.delete()
             return
@@ -312,7 +315,7 @@ class Qanda(commands.Cog):
         q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            await ctx.author.send('No such question with the number: ' + str(num))
             # delete user msg
             await ctx.message.delete()
             return
@@ -350,12 +353,8 @@ class Qanda(commands.Cog):
 
         # send the question and answers to user
         await ctx.author.send(qstr)
-
-        # delete user msg
-        #try:
         await ctx.message.delete()
-        #except NotFound:
-        #    pass
+
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: getAllAnsFor_error(self, ctx, error)
@@ -398,7 +397,7 @@ class Qanda(commands.Cog):
             return
 
         # get questions
-        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s',
+        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s ORDER BY number ASC',
                      (ctx.guild.id,))
         if len(q) == 0:
             await ctx.author.send('No questions found in database.')
@@ -568,7 +567,7 @@ class Qanda(commands.Cog):
             return
 
        # check if question number exists
-        q = db.query('SELECT number, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+        q = db.query('SELECT number, msg_id, is_ghost FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
             await ctx.author.send('Question number not in database: ' + str(num))
@@ -577,6 +576,11 @@ class Qanda(commands.Cog):
             return
 
         q = q[0]
+
+        # if is_ghost is false, set to true
+        if not q[2]:
+            db.query('UPDATE questions SET is_ghost = NOT is_ghost WHERE guild_id = %s AND number = %s',
+            (ctx.guild.id, num))
 
         # check if message exists on channel
         try:

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -3,6 +3,7 @@
 from discord import NotFound
 from discord.ext import commands
 import db
+import re
 
 
 class Qanda(commands.Cog):
@@ -98,6 +99,17 @@ class Qanda(commands.Cog):
             await ctx.author.send('Please send answers to the #q-and-a channel.')
             await ctx.message.delete()
             return
+        
+        # to stop SQL from freezing. Only allows valid numbers.
+        if not re.match('^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+            await ctx.message.delete()
+            return
+        
+        #if not isinstance(ans, str):
+            #await ctx.author.send('Please include a valid answer. EX: $answer 1 /"Oct 12/" anonymous')
+           # await ctx.message.delete()
+           # return
 
         # get author
         if anonymous == '':
@@ -134,7 +146,7 @@ class Qanda(commands.Cog):
         else:
             role = 'Student'
         db.query(
-            'INSERT INTO answers (guild_id, q_number, answer, author_id, author_role) VALUES (%s, %s, %s, %s, %s)',
+            'INSERT INTO answers (guild_id, q_number, answers, author_id, author_role) VALUES (%s, %s, %s, %s, %s)',
             (ctx.guild.id, num, ans, author, role)
         )
 
@@ -176,6 +188,199 @@ class Qanda(commands.Cog):
         else:
             await ctx.author.send(error)
         await ctx.message.delete()
+
+
+    ##### NEW COMMANDS HERE
+    #TODO
+    #getOneAnswer (q_num) (ans_num)
+    #getLatestAnswer (q_num)
+    #deleteAllAnswersFor (q_num) #instructor
+    #deleteOneAnswerFor (q_num) (ans_num) #instructor
+    #deleteEmptyAnswersFor (q_num) #instructor
+    #deleteAllEmptyAnswers #instructor
+
+    #TODO
+    #deleteQuestion (q_num) #ALSO DELETES ALL ANSWERS FOR THIS QUESTION. instructor only
+    #deleteAllQuestions    #instructor only
+    #deleteAllQuestionsBy ... 
+    #deleteAllEmptyQuestions
+
+    #archiveQA (DM all questions and their answers)
+
+
+    #deleteAllAnswersFor (q_num) #instructor
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: deleteAllAnswersFor
+    #    Description: 
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - num: question number
+    #    Outputs:
+    #       - 
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
+    @commands.command(name='DALLAF', help='(PLACEHOLDER NAME) Delete all answers for a question\n'
+                                       'EX: $DALLAF 1')
+    async def deleteAllAnsFor(self, ctx, num):
+
+        # make sure to check that this is actually being asked in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+        
+        # to stop SQL from freezing. Only allows valid numbers.
+        if not re.match('^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+            await ctx.message.delete()
+            return
+        
+        # check if question number exists
+        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+                     (ctx.guild.id, num))
+        if len(q) == 0:
+            await ctx.author.send('Invalid question number: ' + str(num))
+            # delete user msg
+            await ctx.message.delete()
+            return
+        q = q[0]
+
+        # retrieve question msg
+        q_author_str = 'anonymous' if q[2] is None else (await self.bot.fetch_user(q[2])).name
+        qstr = f"Q{q[0]}: {q[1]} by {q_author_str}\n"
+
+        rows_deleted = db.query(
+            'SELECT * FROM answers WHERE guild_id = %s AND q_number = %s',
+            (ctx.guild.id, num)
+        )
+        # Delete all answers for question
+        answers = db.query('DELETE FROM answers WHERE guild_id = %s AND q_number = %s',
+                           (ctx.guild.id, num))
+        
+        if len(rows_deleted) == 0:
+            await ctx.send(
+                f"No answers exist for Q{num}")
+        else:
+            await ctx.send(
+                f"deleted {len(rows_deleted)} answers for Q{num}")
+        
+        # check if message exists on the channel. If it does, restore the question!
+        try:
+            message = await ctx.fetch_message(q[3])
+        except NotFound:
+            nf_str = f"Question {num} not found in channel. It may have been deleted."
+            await ctx.author.send(nf_str)
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        await message.edit(content=qstr)
+        # delete user msg
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: deleteAllAnswersFor_error(self, ctx, error)
+    #    Description: prints error message for deleteAllAnswersFor command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @deleteAllAnsFor.error
+    async def deleteAllAnsFor_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.author.send(
+                'To use the deleteAllAnswersFor command, do: $DALLAF QUESTION_NUMBER\n '
+                '(Example: $DALLAF 1)')
+        else:
+            await ctx.author.send(error)
+        await ctx.message.delete()
+
+    #getAnswersFor (q_num)
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: getAnswersFor
+    #    Description: gets all answers for a question
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - num: question number
+    #    Outputs:
+    #       - All questions and their answers, if any
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.command(name='getAnswersFor', help='Get all answers for a question\n'
+                                       'EX: $getAnswersFor 1')
+    async def getAllAnsFor(self, ctx, num):
+
+        # make sure to check that this is actually being asked in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+
+        # to stop SQL from screaming. Only allows valid numbers.
+        if not re.match('^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+            await ctx.message.delete()
+            return
+        # check if question number exists
+        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+                     (ctx.guild.id, num))
+        if len(q) == 0:
+            await ctx.author.send('Invalid question number: ' + str(num))
+            # delete user msg
+            await ctx.message.delete()
+            return
+        q = q[0]
+
+        # check if message exists
+        try:
+            await ctx.fetch_message(q[3])
+        except NotFound:
+            nf_str = f"Question {num} not found. It may have been deleted."
+            await ctx.author.send(nf_str)
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        # retrieve question msg
+        q_author_str = 'anonymous' if q[2] is None else (await self.bot.fetch_user(q[2])).name
+        qstr = f"Q{q[0]}: {q[1]} by {q_author_str}\n"
+
+
+        # get all answers for question and add to msg
+        answers = db.query('SELECT answer, author_id, author_role FROM answers WHERE guild_id = %s AND q_number = %s',
+                           (ctx.guild.id, num))
+        for answer, author, role in answers:
+            a_author = 'anonymous' if author is None else (await self.bot.fetch_user(author)).name
+            qstr += f"{a_author} ({role}) Ans: {answer}\n"
+        
+        #msgstr = f"Fetched all answers for question {num}"
+
+        await ctx.author.send(qstr)
+
+        # delete user msg
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: getAllAnsFor_error(self, ctx, error)
+    #    Description: prints error message for getAnswersFor command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @getAllAnsFor.error
+    async def getAllAnsFor_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.author.send(
+                'To use the getAnswersFor command, do: $getAnswersFor QUESTION_NUMBER\n '
+                '(Example: $getAnswersFor 1)')
+        else:
+            await ctx.author.send(error)
+        await ctx.message.delete()
+
+
 
 
 def setup(bot):

--- a/init.sql
+++ b/init.sql
@@ -42,5 +42,6 @@ CREATE TABLE questions (
 	number          BIGINT NOT NULL,
     question        VARCHAR NOT NULL,
 	author_id       BIGINT,
-	msg_id          BIGINT NOT NULL
+	msg_id          BIGINT NOT NULL,
+    is_ghost        BOOLEAN DEFAULT false
 );

--- a/init.sql
+++ b/init.sql
@@ -42,7 +42,7 @@ CREATE TABLE questions (
     number          BIGINT NOT NULL,
     question        VARCHAR NOT NULL,
     author_id       BIGINT,
-    msg_id          BIGINT NOT NULL
+    msg_id          BIGINT NOT NULL,
     is_ghost        BOOLEAN DEFAULT false
 );
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -810,6 +810,32 @@ async def test_qanda_errors(bot):
     assert dpytest.verify().message().contains().content(
         "No such question with the number: 1")
 
+    # Test ask: empty question
+    await dpytest.message("$ask \"\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid question.")
+
+    # Test ask: whitepaces only
+    await dpytest.message("$ask \"   \"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid question.")
+
+    # Test ask: one char question
+    await dpytest.message("$ask \"A\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Question too short.")
+
+    # Test answer: empty answer
+    await dpytest.message("$answer 1 \"\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid answer.")
+
+    # Test answer: whitespaces only
+    await dpytest.message("$answer 1 \"    \"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid answer.")
+
+
 # --------------------
 # Tests cogs/reviewQs
 # --------------------

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -304,8 +304,8 @@ async def test_qanda(bot):
     user = dpytest.get_config().members[0]
     guild = dpytest.get_config().guilds[0]
     channel = await guild.create_text_channel('q-and-a')
-    gen_channel = await guild.create_text_channel('general')
-    await guild.create_role(name="Instructor")
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
     role = discord.utils.get(guild.roles, name="Instructor")
     await dpytest.add_role(user, role)
 
@@ -319,10 +319,279 @@ async def test_qanda(bot):
     assert dpytest.verify().message().contains().content(
         'Q2: When is the last day of classes? by ' + user.name)
 
-    # placeholder test for empty input (question)
-    #await dpytest.message("$ask \"\"", channel=channel)
-    #assert dpytest.verify().message().contains().content('STRING GOES HERE')
-    
+    # Tests getting answers: no answers
+    await dpytest.message("$getAnswersFor 1", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'No answers for Q1')
+
+    # Test answering a question
+    await dpytest.message("$answer 2 \"TestA\"", channel=channel)
+    # Test answering a question anonymously
+    await dpytest.message("$answer 2 \"TestB\" anonymous", channel=channel)
+
+    # Tests getting answers: question has answers
+    await dpytest.message("$getAnswersFor 2", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q2: When is the last day of classes? by ' + user.name + '\n'
+        + user.name + ' (Instructor) Ans: TestA\n'
+        'anonymous (Instructor) Ans: TestB\n')
+
+    # Tests channelGhost: not a ghost, has answers
+    await dpytest.message("$channelGhost 2", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'This question is not a ghost. Fetching anyway. . .')
+    assert dpytest.verify().message().contains().content(
+        'Q2: When is the last day of classes? by ' + user.name + '\n'
+        + user.name + ' (Instructor) Ans: TestA\n'
+        'anonymous (Instructor) Ans: TestB\n')
+
+    # test deleting all answers for a question with none
+    await dpytest.message("$DALLAF 1", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'No answers exist for Q1')
+
+    # test deleting all answers
+    await dpytest.message("$DALLAF 2", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'deleted 2 answers for Q2')
+
+    # Test reviveGhost: non-existent question
+    await dpytest.message("$reviveGhost 100", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "No such question with the number: 100")
+
+    # Test channelGhost: non-existent question
+    await dpytest.message("$channelGhost 100", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "No such question with the number: 100")
+
+    # GHOST AND ZOMBIE TESTING
+
+    # ask and dequeue
+    await dpytest.message("$ask \"Am I a zombie?\" anonymous", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q3: Am I a zombie? by anonymous')
+
+    # hold on to q3
+    q3_id = channel.last_message_id
+    q3 = await channel.fetch_message(q3_id)
+
+    # Tests channelGhost: not a ghost, no answers
+    await dpytest.message("$channelGhost 3", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'This question is not a ghost. Fetching anyway. . .')
+    assert dpytest.verify().message().contains().content(
+        'Q3: Am I a zombie? by anonymous\n'
+        'No answers for Q3\n')
+
+    # Test spooky: no ghosts or zombies
+    await dpytest.message("$spooky", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "This channel isn't haunted.")
+
+    # Test unearthZombies: no zombies
+    await dpytest.message("$unearthZombies", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "No zombies detected.")
+
+    # zomb-ify Q3
+    await q3.delete()
+
+    # test answering a zombie
+    await dpytest.message("$answer 3 \"zombie test\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Question 3 not found. It's a zombie!"
+    )
+
+    # test getting answers for a zombie
+    await dpytest.message("$getAnswersFor 3", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Question 3 not found. It's a zombie!"
+    )
+
+    # ask and dequeue
+    await dpytest.message("$ask \"Am I a ghost?\" anonymous", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4: Am I a ghost? by anonymous')
+    # answer Q4
+    await dpytest.message("$answer 4 \"Yes\" anonymous", channel=channel)
+
+    # ask and dequeue
+    await dpytest.message("$ask \"Zombie\" anonymous", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q5: Zombie by anonymous')
+
+    # hold on to q5
+    q5_id = channel.last_message_id
+    q5 = await channel.fetch_message(q5_id)
+
+    # answer Q5; zombie with an answer
+    await dpytest.message("$answer 5 \"test\" anonymous", channel=channel)
+
+    # Test deleting a question
+    await dpytest.message("$deleteQuestion 4", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4 is now a ghost. To restore it, use: $reviveGhost 4')
+
+    # Test deleting a ghost question
+    await dpytest.message("$deleteQuestion 4", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4 is already a ghost!')
+
+    # test answering a ghost
+    await dpytest.message("$answer 4 \"Ghost Test\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "You can\'t answer a ghost!"
+    )
+
+
+    # Test channelGhost: answers
+    await dpytest.message("$channelGhost 4", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4: Am I a ghost? by anonymous\nanonymous (Instructor) Ans: Yes\n'
+    )
+
+    # Tests getting answers for a ghost
+    await dpytest.message("$getAnswersFor 4", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4 is a ghost!')
+
+    # Test allChannelGhosts: answers
+    await dpytest.message("$allChannelGhosts", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4: Am I a ghost? by anonymous\n'
+        'anonymous (Instructor) Ans: Yes\n')
+
+    # test deleting all answers for ghost
+    await dpytest.message("$DALLAF 4", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'deleted 1 answers for Q4')
+    assert dpytest.verify().message().contains().content(
+        'Q4 is a ghost!')
+
+    # Test channelGhost: no answers
+    await dpytest.message("$channelGhost 4", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4: Am I a ghost? by anonymous\n'
+        'No answers for Q4\n')
+
+    # Test allChannelGhosts: no answers
+    await dpytest.message("$allChannelGhosts", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q4: Am I a ghost? by anonymous\n'
+        'No answers for Q4\n')
+
+    # Test spooky: ghosts and zombies are present
+    await dpytest.message("$spooky", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'This channel is haunted by 1 ghosts and 1 zombies.')
+
+    # Test archiveQA: zombie, ghost, questions with and without answers
+    await dpytest.message("$archiveQA",channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q1: What class is this? by anonymous\n'
+        'No answers for Q1\n')
+    assert dpytest.verify().message().contains().content(
+        'Q2: When is the last day of classes? by ' + user.name + '\n'
+        'No answers for Q2\n')
+    assert dpytest.verify().message().contains().content(
+        "Q3 was deleted. It's a zombie!")
+    assert dpytest.verify().message().contains().content(
+        'Q4 is a ghost!')
+    assert dpytest.verify().message().contains().content(
+        'Q5: Zombie by anonymous\n'
+        'anonymous (Instructor) Ans: test\n')
+
+    # Test reviving a ghost (revive without answers)
+    await dpytest.message("$reviveGhost 4", channel=channel)
+    # no assert needed!
+
+    # ghosts: 0, zombies: 1
+
+    # Test deleting a zombie (ghosts + 1, zombies -1)
+    await dpytest.message("$deleteQuestion 3", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q3 was not found in channel. To restore it, use: $reviveGhost 3')
+
+    # ghosts: 1, zombies: 0
+
+    # zomb-ify Q5
+    await q5.delete()
+
+    # ghosts: 1, zombies: 1
+
+    # test reviving a zombie with answers
+    await dpytest.message("$reviveGhost 5", channel=channel)
+    # now we can assert because a message is actually posted this time.
+    assert dpytest.verify().message().contains().content(
+        'Q5: Zombie by anonymous\n'
+        'anonymous (Instructor) Ans: test\n')
+
+    # ghosts: 1, zombies: 0
+
+    # create another zombie
+    await dpytest.message("$ask \"Zombie2\" anonymous", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q6: Zombie2 by anonymous')
+
+    # hold on to q5
+    q6_id = channel.last_message_id
+    q6 = await channel.fetch_message(q6_id)
+    await q6.delete()
+
+    # test unearthZombies: zombies found
+    await dpytest.message("$unearthZombies", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Found 1 zombies and assigned them ghost status.\n"
+        "To view them, use: $allChannelGhosts\n"
+        "To restore a question, use: $reviveGhost QUESTION_NUMBER")
+
+    # ghosts: 2, zombies: 0
+
+    # create final zombie
+    await dpytest.message("$ask \"Zombie3\" anonymous", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Q7: Zombie3 by anonymous')
+    # hold on to q7
+    qz_id = channel.last_message_id
+    qz = await channel.fetch_message(qz_id)
+
+    await dpytest.message("$answer 7 \"test\" anonymous", channel=channel)
+
+    # zomb-ify Q7
+    await qz.delete()
+
+    # ghosts: 2, zombies: 1
+
+    # test deleting all answers for zombie
+    await dpytest.message("$DALLAF 7", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'deleted 1 answers for Q7')
+    assert dpytest.verify().message().contains().content(
+        'Q7 is a zombie!')
+
+    # test deleteAllQA: questions with and without answers, ghosts and zombies
+    await dpytest.message("$deleteAllQA", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Deleted 7 questions from the database, including 1 zombies and 2 ghosts.")
+
+
+# -------------------------
+# Tests cogs/qanda: error testing
+# -------------------------
+@pytest.mark.asyncio
+async def test_qanda_errors(bot):
+    # Test q and a functionalities
+    # create channel and get user
+    user = dpytest.get_config().members[0]
+    guild = dpytest.get_config().guilds[0]
+    channel = await guild.create_text_channel('q-and-a')
+    gen_channel = await guild.create_text_channel('general')
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
+    role = discord.utils.get(guild.roles, name="Instructor")
+    await dpytest.add_role(user, role)
+
     # Test asking a question in the wrong channel
     msg = await dpytest.message("$ask \"Is this the right channel?\"", channel=gen_channel)
     with pytest.raises(discord.NotFound):
@@ -348,7 +617,7 @@ async def test_qanda(bot):
         await gen_channel.fetch_message(msga.id)
     assert dpytest.verify().message().contains().content(
         'Please send answers to the #q-and-a channel.')
-    
+
     # Tests unknown anonymous input (answer)
     await dpytest.message("$answer 1 \"A Thing\" wronganon", channel=channel)
     assert dpytest.verify().message().contains().content(
@@ -399,42 +668,6 @@ async def test_qanda(bot):
     assert dpytest.verify().message().contains().content(
         'Please include a valid question number. EX: $getAnswersFor 1')
 
-    # Tests getting answers: no answers
-    await dpytest.message("$getAnswersFor 1", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'No answers for Q1')
-
-    # Test archiveQA: questions without answers
-    await dpytest.message("$archiveQA",channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Q1: What class is this? by anonymous\n'
-        'No answers for Q1\n')
-    assert dpytest.verify().message().contains().content(
-        'Q2: When is the last day of classes? by ' + user.name + '\n'
-        'No answers for Q2\n')
-
-    # Test answering a question
-    await dpytest.message("$answer 2 \"TestA\"", channel=channel)
-    # Test answering a question anonymously
-    await dpytest.message("$answer 2 \"TestB\" anonymous", channel=channel)
-
-    # Tests getting answers: question has answers
-    await dpytest.message("$getAnswersFor 2", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Q2: When is the last day of classes? by ' + user.name + '\n'
-        + user.name + ' (Instructor) Ans: TestA\n'
-        'anonymous (Instructor) Ans: TestB\n')
-
-    # Test archiveQA: questions with answers
-    await dpytest.message("$archiveQA",channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Q1: What class is this? by anonymous\n'
-        'No answers for Q1\n')
-    assert dpytest.verify().message().contains().content(
-        'Q2: When is the last day of classes? by ' + user.name + '\n'
-        + user.name + ' (Instructor) Ans: TestA\n'
-        'anonymous (Instructor) Ans: TestB\n')
-
     # Test that deleting answers does not work outside of QA
     msg = await dpytest.message("$DALLAF 1", channel=gen_channel)
     with pytest.raises(discord.NotFound):
@@ -458,29 +691,6 @@ async def test_qanda(bot):
     await dpytest.message("$DALLAF 100", channel=channel)
     assert dpytest.verify().message().contains().content(
         'No such question with the number: 100')
-
-    # test deleting all answers for a question with none
-    await dpytest.message("$DALLAF 1", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'No answers exist for Q1')
-
-    # test deleting all answers
-    await dpytest.message("$DALLAF 2", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'deleted 2 answers for Q2')
-
-    # Test archiveQA again; ensure proper deletion
-    await dpytest.message("$archiveQA",channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Q1: What class is this? by anonymous\n'
-        'No answers for Q1\n')
-    assert dpytest.verify().message().contains().content(
-        'Q2: When is the last day of classes? by ' + user.name + '\n'
-        'No answers for Q2\n')
-
-    # answer a question
-    await dpytest.message("$answer 1 \"TestC\"", channel=channel)
-    await dpytest.message("$answer 1 \"TestD\" anonymous", channel=channel)
 
     # Test that deleting questions does not work outside of QA
     msg = await dpytest.message("$deleteQuestion 1", channel=gen_channel)
@@ -506,67 +716,100 @@ async def test_qanda(bot):
     assert dpytest.verify().message().contains().content(
         'Question number not in database: 100')
 
-    # Test deleting a question
-    await dpytest.message("$deleteQuestion 1", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Q1 is now a ghost. To see ghost handling options, use the $help command.')
-
-    # Test deleting a ghost question
-    await dpytest.message("$deleteQuestion 1", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Q1 is already a ghost!')
-
-    # Tests getting answers for a ghost
-    await dpytest.message("$getAnswersFor 1", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Question 1 not found. It may have been deleted.')
-
-    # test deleting all answers for ghost
-    await dpytest.message("$DALLAF 1", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'deleted 2 answers for Q1')
-    assert dpytest.verify().message().contains().content(
-        'Q1 is a ghost!')
-
-    # Test archiveQA again; ensure haunting
-    await dpytest.message("$archiveQA",channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Q1 is a ghost!')
-    assert dpytest.verify().message().contains().content(
-        'Q2: When is the last day of classes? by ' + user.name + '\n'
-        'No answers for Q2\n')
-
     # Test that deleting all QAs does not work outside of QA
-    msg = await dpytest.message("$deleteAllQA", channel=gen_channel)
-    with pytest.raises(discord.NotFound):
-        await gen_channel.fetch_message(msg.id)
+    await dpytest.message("$deleteAllQA", channel=gen_channel)
     assert dpytest.verify().message().contains().content(
         'Please use this command inside the #q-and-a channel.')
-
-    # Test deleting all QAs
-    await dpytest.message("$deleteAllQA", channel=channel)
-    assert dpytest.verify().message().contains().content(
-        'Deleted 2 questions from the database, including 1 ghost questions.')
 
     # Test deleting all QAs without any questions
     await dpytest.message("$deleteAllQA", channel=channel)
     assert dpytest.verify().message().contains().content(
         'No questions found in database.')
 
-    # Test archiveQA again: deleting all QAs
+    # Test archiveQA: empty database
     await dpytest.message("$archiveQA",channel=channel)
     assert dpytest.verify().message().contains().content(
         'No questions found in database.')
 
     # Test that archiveQA does not work outside of QA
     await dpytest.message("$archiveQA", channel=gen_channel)
-    with pytest.raises(discord.NotFound):
-        await gen_channel.fetch_message(msg.id)
-    # Tests that the bot sent the appropriate message
+    assert dpytest.verify().message().contains().content(
+        'Please use this command inside the #q-and-a channel.')
+
+    # Test channelGhost in the wrong channel
+    await dpytest.message("$channelGhost 1", channel=gen_channel)
+    assert dpytest.verify().message().contains().content(
+        'Please use this command inside the #q-and-a channel.')
+
+    # Tests channelGhost: missing args
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message("$channelGhost", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'To use the channelGhost command, do: $channelGhost QUESTION_NUMBER\n '
+        '(Example: $channelGhost 1)')
+
+    # Tests channelGhost: invalid arg
+    await dpytest.message("$channelGhost blah", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Please include a valid question number. EX: $channelGhost 1')
+
+    # Tests channelGhost: empty database
+    await dpytest.message("$channelGhost 1", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'No such question with the number: 1')
+
+    # Test allChannelGhosts in the wrong channel
+    await dpytest.message("$allChannelGhosts", channel=gen_channel)
     assert dpytest.verify().message().contains().content(
         'Please use this command inside the #q-and-a channel.')
 
 
+    # allChannelGhosts without any ghosts
+    await dpytest.message("$allChannelGhosts", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'No ghosts found in database.')
+
+    # Test spooky in the wrong channel
+    await dpytest.message("$spooky", channel=gen_channel)
+    assert dpytest.verify().message().contains().content(
+        'Please use this command inside the #q-and-a channel.')
+
+    # Test spooky: empty database
+    await dpytest.message("$spooky", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "This channel isn't haunted.")
+
+    # Test unearthZombies in the wrong channel
+    await dpytest.message("$unearthZombies", channel=gen_channel)
+    assert dpytest.verify().message().contains().content(
+        'Please use this command inside the #q-and-a channel.')
+
+    # Test unearthZombies: empty database
+    await dpytest.message("$unearthZombies", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "No zombies detected.")
+
+    # Test reviveGhost in the wrong channel
+    await dpytest.message("$reviveGhost 1", channel=gen_channel)
+    assert dpytest.verify().message().contains().content(
+        'Please use this command inside the #q-and-a channel.')
+
+    # Tests reviveGhost: missing args
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message("$reviveGhost", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'To use the reviveGhost command, do: $reviveGhost QUESTION_NUMBER\n '
+        '(Example: $reviveGhost 1)')
+
+    # Tests reviveGhost: invalid arg
+    await dpytest.message("$reviveGhost blah", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        'Please include a valid question number. EX: $reviveGhost 1')
+
+    # Test reviveGhost: empty database
+    await dpytest.message("$reviveGhost 1", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "No such question with the number: 1")
 
 # --------------------
 # Tests cogs/reviewQs

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -368,7 +368,7 @@ async def test_qanda(bot):
     # GHOST AND ZOMBIE TESTING
 
     # ask and dequeue
-    await dpytest.message("$ask \"Am I a zombie?\" anonymous", channel=channel)
+    await dpytest.message("$ask \"Am I a zombie?\" anon", channel=channel)
     assert dpytest.verify().message().contains().content(
         'Q3: Am I a zombie? by anonymous')
 
@@ -414,7 +414,7 @@ async def test_qanda(bot):
     assert dpytest.verify().message().contains().content(
         'Q4: Am I a ghost? by anonymous')
     # answer Q4
-    await dpytest.message("$answer 4 \"Yes\" anonymous", channel=channel)
+    await dpytest.message("$answer 4 \"Yes\" anon", channel=channel)
 
     # ask and dequeue
     await dpytest.message("$ask \"Zombie\" anonymous", channel=channel)
@@ -602,7 +602,7 @@ async def test_qanda_errors(bot):
     # Tests unknown anonymous input (question)
     await dpytest.message("$ask \"Who am I?\" wronganon", channel=channel)
     assert dpytest.verify().message().contains().content(
-        'Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+        'Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
 
     # Tests incorrect use of ask command: missing args
     with pytest.raises(commands.MissingRequiredArgument):
@@ -621,7 +621,7 @@ async def test_qanda_errors(bot):
     # Tests unknown anonymous input (answer)
     await dpytest.message("$answer 1 \"A Thing\" wronganon", channel=channel)
     assert dpytest.verify().message().contains().content(
-        'Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+        'Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
 
     # Tests answering a nonexistent question (answer)
     await dpytest.message("$answer 100 \"nope\"", channel=channel)
@@ -762,7 +762,6 @@ async def test_qanda_errors(bot):
     await dpytest.message("$allChannelGhosts", channel=gen_channel)
     assert dpytest.verify().message().contains().content(
         'Please use this command inside the #q-and-a channel.')
-
 
     # allChannelGhosts without any ghosts
     await dpytest.message("$allChannelGhosts", channel=channel)


### PR DESCRIPTION
### Summary

<!-- Summarize this PR here! -->

~Added 5 new commands, 41 unit tests, and set up for ghost handling.~
~qanda.py coverage increased from **35%** to **92%**~

* Added 10 new commands and 75 unit tests.
* Users can now use "anon" when answering/asking questions.
* Fixed bug that allowed users to ask empty/blank/whitespace only questions
* Fixed bug that allowed users to write blank/empty/whitespace only answers
* qanda.py coverage increased from **35%** to **95%**

New commands:

**$getAnswersFor (num)** -- get all answers for a question. Ignores ghosts and zombies.
**$DALLAF (num)** -- deletes all answers for a question. Instructor only.
**$archiveQA** -- sends all questions and answers to the user via DM. Ignores ghosts and zombies.
**$deleteAllQA**: deletes all questions and answers from the database and channel. Also cleans up ghosts and zombies. Instructor only.
**$deleteQuestion (num):** deletes a single question from the channel and leaves a database ghost. Instructor only.

Round 2 was supposed to be the database integrity update, but it was included here. (Finished on 11/19, included on 11/21)

**$spooky:** Used to check the number of zombies and ghosts in the channel. Fun for students, practical for instructors.
**$channelGhost (num):** Get the ghost question and its answers with that number. Also works for zombies and non-ghost questions. (Basically, getAnswersFor but doesn't ignore ghosts or zombies.) Instructor only.
**$allChannelGhosts:** get all channel ghosts via DM. Instructor only.
**$reviveGhost (num):** Restores a ghost question (and answers). Instructor only.
**$unearthZombies:** gets all zombies (manually deleted questions) and assigns ghost status. Instructor only.

NOTE:

**Ghosts** are questions that have been "hidden" via the deleteQuestion command and can be restored. They're flagged as ghosts in the database.

**Zombies** are questions that have been manually deleted. They don't have ghost status so they won't show up with the allChannelGhosts command. Using reviveGhost on a zombie basically reposts the question to the channel and updates the msg_id in the database.


### Changed Files

<!-- None OR list all changed files -->

qanda.py

New commands:
```
$getAnswersFor (num)
$DALLAF (num)
$archiveQA
$deleteAllQA
$deleteQuestion (num)
$spooky
$channelGhost (num)
$allChannelGhosts
$reviveGhost (num)
$unearthZombies
```
Added regex to all functions that require a num arg to only allow valid input
Added is_ghost column to questions table in init.sql (AND to the database itself)
Users can now use "anon" when answering/asking questions
Fixed bug that allowed users to ask empty/blank/whitespace only questions

test_bot.py:
Added 70 unit tests: exhaustive, see [Datebase integrity update, ghost commands, unit tests](https://github.com/CSC510-Group-25/ClassMateBot/pull/82/commits/fd0a38c940e4aa44d620c201f487ac2c1674e13c)

init.sql:
Added is_ghost column to questions table

### Checklists

<!-- If your changes don't affect working code, delete all checkboxes and write N/A -->

- [x] Did you test your changes locally?  
- [x] Did your changes pass all existing tests?  
- [x] Do test cases exist for your changes? If not, please make or reopen an issue.

----

#### Closing Issues

**Please leave a comment on these issues before approving this PR.**

Resolves #79 Q&A bug: empty strings are allowed
Resolves #70 qanda.py: Increase coverage to at least 75%
Resolves #64 Allow users to type "anon" or "anonymous" for Q&A
Resolves #10 Enhance Q and A
Resolves #11 Command to list all of the questions and answers
Resolves #12 Allow deleting questions/answers
Resolves #13 Allow users to get a specific question


#### Bugs, Notes

~Ghosts will be handled in Q&A **round 2**.~

<!-- Need help with something? Use the 'Help Wanted' tag and write a short summary of what the problem is --> 
<!-- If there's a bug you can't fix, make an issue and use the 'Help wanted' and 'bug' tags! --> 

[Added commands: getAnswersFor, deleteAllAnswersFor](https://github.com/CSC510-Group-25/ClassMateBot/commit/191882fe9435f110bf160d634218120d2ec0fc85)
[Added archiveQA command, unit tests ](https://github.com/CSC510-Group-25/ClassMateBot/pull/82/commits/7bff7fff1ba63111cb8a9635b13b1a38ba7d0199)
[New commands: deleteAllQA, deleteQuestion](https://github.com/CSC510-Group-25/ClassMateBot/pull/82/commits/eb0e02fc6dab9f770c46743c69854e95e3c657b3)
[](https://github.com/CSC510-Group-25/ClassMateBot/pull/82/commits/58b7ae683965d12ff2a08674631b07e4dcf8acc4)

[Datebase integrity update, ghost commands, unit tests](https://github.com/CSC510-Group-25/ClassMateBot/pull/82/commits/fd0a38c940e4aa44d620c201f487ac2c1674e13c)

#### Contributors

@snapcat 
