### PR TITLE
[Fix] censoring bugs in bot.py and Q&A commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -151,7 +151,7 @@ async def on_message(message):
     if profanity_helper.filtering:
         if cname != 'instructor-commands':
             nustr = message.content.replace('"','')
-            if profanity_helper.helpChecker(nustr):
+            if profanity_helper.helpChecker(nustr) or profanity_helper.helpChecker(message.content):
             #if profanity_helper.helpChecker(message.content):
                 badmsg = "Please do not use inappropriate language in this server. Your message:\n"
                 badmsg += profanity_helper.helpCensor(nustr)

--- a/bot.py
+++ b/bot.py
@@ -137,6 +137,7 @@ async def on_ready():
 async def on_message(message):
     ''' run on message sent to a channel '''
     # allow messages from test bot
+    # NOTE from Group25: Not sure if this is actually being used anywhere.
     if message.author.bot and message.author.id == 889697640411955251:
         ctx = await bot.get_context(message)
         await bot.invoke(ctx)
@@ -144,13 +145,22 @@ async def on_message(message):
     if message.author == bot.user:
         return
 
+    cname = message.channel.name
+    # CHECK CHANNELS.
     # don't want to accidentally censor a word before it can be whitelisted
-    if "whitelist" not in message.content:
-        if profanity_helper.filtering and profanity_helper.helpChecker(message.content):
-            await message.channel.send(message.author.name + ' says: ' +
-                profanity_helper.helpCensor(message.content))
-            await message.delete()
-
+    if profanity_helper.filtering:
+        if cname != 'instructor-commands':
+            nustr = message.content.replace('"','')
+            if profanity_helper.helpChecker(nustr):
+            #if profanity_helper.helpChecker(message.content):
+                badmsg = "Please do not use inappropriate language in this server. Your message:\n"
+                badmsg += profanity_helper.helpCensor(nustr)
+                #badmsg += profanity_helper.helpCensor(message.content)
+                #if message.author.bot: # if the author is the bot
+                    #return
+                await message.author.send(badmsg)
+                await message.delete()
+                return
     await bot.process_commands(message)
 
 
@@ -166,14 +176,15 @@ async def on_message(message):
 async def on_message_edit(before, after):
     ''' run on message edited '''
 
-    # TODO: this can cause a message not found error with qanda
     if profanity_helper.filtering:
         if profanity_helper.helpChecker(after.content):
-            await after.channel.send(after.author.name + ' says: ' +
-                profanity_helper.helpCensor(after.content))
-            await after.delete()
-
-
+            if not after.author.bot:
+                await after.channel.send(after.author.name + ' says: ' +
+                    profanity_helper.helpCensor(after.content))
+                await after.delete()
+            else:
+                numsg = profanity_helper.helpCensor(after.content)
+                await after.edit(content=numsg)
 
 # -----------------------------------------------------------------------
 #    Function: toggleFilter
@@ -204,7 +215,7 @@ async def toggleFilter(ctx):
 # ------------------------------------------------------------------------
 @bot.command(name="whitelist", help="adds a word to the whitelist. EX: $whitelist word or sentence")
 @has_permissions(administrator=True)
-async def whitelistWord(ctx, *, word=''):
+async def whitelistWord(ctx, *, word =''):
 
     if not ctx.channel.name == 'instructor-commands':
         await ctx.author.send('Please use this command inside #instructor-commands')

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -5,7 +5,6 @@ from discord.ext import commands
 import db
 import re
 
-
 class Qanda(commands.Cog):
 
     def __init__(self, bot):


### PR DESCRIPTION
### Summary

<!-- Summarize this PR here! -->

The bot now prevents messages containing profanity from being posted. It also notifies the user if their message contains profanity.

Fixes:

Profanity filter fails when asking/answering questions #76
Command raised an exception: NotFound: 404 Not Found (error code: 10008): Unknown Message #77
Profanity filter workaround: using the word "whitelist" outside of commands #104

### Changed Files

bot.py

qanda.py (whitespace change)

### Checklist

<!-- If your changes don't affect working code, delete all checkboxes and write N/A -->

- [x] Did you test your changes locally?  
- [x] Did your changes pass all existing tests?  
~- [ ] Do test cases exist for your changes? If not, please make an issue.~

Fun with manual tests!

----

#### Closing Issues

Resolves #76
Resolves #77 
Resolves #104

#### Notes


#### Contributors

@snapcat 
