### PR TITLE
Group25 deadline enhance

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,6 +50,9 @@ async def on_guild_join(guild):
             if 'q-and-a' not in guild.text_channels:
                 await guild.create_text_channel('q-and-a')
                 await channel.send("q-and-a channel has been added!")
+            if 'reminders' not in guild.text_channels:
+                await guild.create_text_channel('reminders')
+                await channel.send("reminders channel has been added!")
 
             if discord.utils.get(guild.roles, name="verified") is None:
                 await guild.create_role(name="verified", colour=discord.Colour(0x2ecc71),

--- a/cogs/deadline.py
+++ b/cogs/deadline.py
@@ -246,7 +246,7 @@ class Deadline(commands.Cog):
         reminders = db.query(
             "SELECT course, homework, due_date "
             "FROM reminders "
-            "WHERE guild_id = %s AND date_part('day', due_date - now()) <= 7",
+            "WHERE guild_id = %s AND date_part('day', due_date - now()) <= 7 AND due_date < now()",
             (ctx.guild.id,)
         )
 
@@ -289,7 +289,7 @@ class Deadline(commands.Cog):
         due_today = db.query(
             "SELECT course, homework, due_date "
             "FROM reminders "
-            "WHERE guild_id = %s AND due_date::date = now()::date",
+            "WHERE guild_id = %s AND date_part('day', due_date - now()) <= 1 AND due_date < now()",
             (ctx.guild.id,)
         )
         for course, homework, due_date in due_today:

--- a/cogs/deadline.py
+++ b/cogs/deadline.py
@@ -550,12 +550,13 @@ class Deadline(commands.Cog):
     @tasks.loop(hours=24)
     async def send_reminders_day(self):
         channel = discord.utils.get(self.bot.get_all_channels(), name="reminders")
-        reminders = db.query("SELECT course, homework, due_date "
-            "FROM reminders "
-            "WHERE due_date::date = now()::date")
-        for course,homework,due_date in reminders:
-            difference = due_date - datetime.now(timezone.utc)
-            await channel.send(f"{homework} for {course} is due in {(difference.seconds//3600)} hours")
+        if channel:
+            reminders = db.query("SELECT course, homework, due_date "
+                "FROM reminders "
+                "WHERE due_date::date = now()::date")
+            for course,homework,due_date in reminders:
+                difference = due_date - datetime.now(timezone.utc)
+                await channel.send(f"{homework} for {course} is due in {(difference.seconds//3600)} hours")
 
     
     # -----------------------------------------------------------------------------------------------------
@@ -582,13 +583,14 @@ class Deadline(commands.Cog):
     @tasks.loop(hours=1)
     async def send_reminders_hour(self):
         channel = discord.utils.get(self.bot.get_all_channels(), name="reminders")
-        reminders = db.query("SELECT course, homework, due_date "
-            "FROM reminders "
-            "WHERE due_date::date = now()::date")
-        for course,homework,due_date in reminders:
-            difference = due_date - datetime.now(timezone.utc)
-            if difference.seconds//3600 == 0:
-                await channel.send(f"{homework} for {course} is due within the hour")
+        if channel:
+            reminders = db.query("SELECT course, homework, due_date "
+                "FROM reminders "
+                "WHERE due_date::date = now()::date")
+            for course,homework,due_date in reminders:
+                difference = due_date - datetime.now(timezone.utc)
+                if difference.seconds//3600 == 0:
+                    await channel.send(f"{homework} for {course} is due within the hour")
 
 
 
@@ -597,11 +599,6 @@ class Deadline(commands.Cog):
 # -------------------------------------
 def setup(bot):
     n = Deadline(bot)
-    loop = asyncio.get_event_loop()
-
-    WHEN = time(18, 0, 0)  # 6:00 PM
-
-    # loop.create_task(n.delete_old_reminders())
     n.send_reminders_day.start()
     n.send_reminders_hour.start()
     bot.add_cog(n)

--- a/cogs/deadline.py
+++ b/cogs/deadline.py
@@ -246,7 +246,7 @@ class Deadline(commands.Cog):
         reminders = db.query(
             "SELECT course, homework, due_date "
             "FROM reminders "
-            "WHERE guild_id = %s AND date_part('day', due_date - now()) <= 7 AND due_date < now()",
+            "WHERE guild_id = %s AND date_part('day', due_date - now()) <= 7 AND date_part('minute', due_date - now()) >= 0",
             (ctx.guild.id,)
         )
 
@@ -289,7 +289,7 @@ class Deadline(commands.Cog):
         due_today = db.query(
             "SELECT course, homework, due_date "
             "FROM reminders "
-            "WHERE guild_id = %s AND date_part('day', due_date - now()) <= 1 AND due_date < now()",
+            "WHERE guild_id = %s AND date_part('day', due_date - now()) <= 1 AND date_part('minute', due_date - now()) >= 0",
             (ctx.guild.id,)
         )
         for course, homework, due_date in due_today:

--- a/cogs/deadline.py
+++ b/cogs/deadline.py
@@ -16,8 +16,6 @@ import discord
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import db
 
-bot = commands.Bot("!")
-
 class Deadline(commands.Cog):
 
     def __init__(self, bot):
@@ -38,8 +36,7 @@ class Deadline(commands.Cog):
                            "datetime notifications $timenow MMM DD YYYY HH:MM ex. $timenow SEP 25 2024 17:02")
     async def timenow(self, ctx, *, date: str):
         try:
-            duedate = parser.parse(date)
-            print(duedate)
+            input_time = parser.parse(date)
         except ValueError:
             await ctx.send("Due date could not be parsed")
             return
@@ -92,7 +89,6 @@ class Deadline(commands.Cog):
 
         try:
             duedate = parser.parse(date)
-            print(duedate)
         except ValueError:
             await ctx.send("Due date could not be parsed")
             return
@@ -558,10 +554,9 @@ class Deadline(commands.Cog):
                 difference = due_date - datetime.now(timezone.utc)
                 await channel.send(f"{homework} for {course} is due in {(difference.seconds//3600)} hours")
 
-    
     # -----------------------------------------------------------------------------------------------------
     #    Function: bofore(self)
-    #    Description: runs once per day and waits until 8:00 AM EST to send reminders via the send 
+    #    Description: runs once per day and waits until 8:00 AM EST to send reminders via the send
     #       reminders day function
     #    Inputs:
     #    - self: used to access parameters passed to the class through the constructor
@@ -570,10 +565,13 @@ class Deadline(commands.Cog):
     async def before(self):
         WHEN = time(13, 0, 0) # 8:00 AM eastern
         now = datetime.utcnow()
-        target_time = datetime.combine(now.date(), WHEN) 
+        target_time = datetime.combine(now.date(), WHEN)
         seconds_until_target = (target_time - now).total_seconds()
-        await asyncio.sleep(seconds_until_target)  
-            
+        if seconds_until_target < 0:
+            target_time = datetime.combine(now.date()+timedelta(days=1), WHEN)
+            seconds_until_target = (target_time - now).total_seconds()
+        await asyncio.sleep(seconds_until_target)
+
     # -----------------------------------------------------------------------------------------------------
     #    Function: send_reminders_hour(self)
     #    Description: task that runs once per hours and sends a reminders for assignments due
@@ -591,8 +589,6 @@ class Deadline(commands.Cog):
                 difference = due_date - datetime.now(timezone.utc)
                 if difference.seconds//3600 == 0:
                     await channel.send(f"{homework} for {course} is due within the hour")
-
-
 
 # -------------------------------------
 # add the file to the bot's cog system

--- a/cogs/deadline.py
+++ b/cogs/deadline.py
@@ -8,6 +8,7 @@
 import os
 import asyncio
 from datetime import datetime, timedelta
+from dateutil import parser
 import sys
 from discord.ext import commands
 
@@ -59,13 +60,15 @@ class Deadline(commands.Cog):
     #          indicating that the reminder has been added
     # -----------------------------------------------------------------------------------------------------------------
     @commands.command(name="addhw",
-                      help="add homework and due-date $addhw CLASSNAME HW_NAME MMM DD YYYY optional(HH:MM) "
+                      help="add homework and due-date $addhw CLASSNAME HW_NAME MMM DD YYYY optional(HH:MM)"
                       "ex. $addhw CSC510 HW2 SEP 25 2024 17:02")
     async def duedate(self, ctx, coursename: str, hwcount: str, *, date: str):
         author = ctx.message.author
 
         try:
-            duedate = datetime.strptime(date, '%b %d %Y %H:%M')
+            duedate = parser.parse(date)
+            print(duedate)
+            # duedate = datetime.strptime(date, '%b %d %Y %H:%M')
             # print(seconds)
         except ValueError:
             try:

--- a/cogs/deadline.py
+++ b/cogs/deadline.py
@@ -256,16 +256,11 @@ class Deadline(commands.Cog):
 
         for course, homework, due_date in reminders:
             delta = due_date - curr_date
-            formatted_due_date = due_date.strftime("%b %d %Y %H:%M:%S")
-            await ctx.send(f"{course} {homework} is due in {delta.days} days, {delta.seconds//3600}"
+            formatted_due_date = due_date.strftime("%b %d %Y %H:%M:%S%z")
+            await ctx.author.send(f"{course} {homework} is due in {delta.days} days, {delta.seconds//3600}"
                             f" hours and {(delta.seconds//60)%60} minutes ({formatted_due_date})")
+        await ctx.message.delete()
 
-        # for reminder in self.reminders:
-        #     timeleft = datetime.strptime(reminder["DUEDATE"], '%Y-%m-%d %H:%M:%S') - time
-        #     print("timeleft: " + str(timeleft) + " days left: " + str(timeleft.days))
-        #     if timeleft.days <= 7:
-        #         await ctx.send("{} {} is due this week at {}".format(reminder["COURSE"], reminder["HOMEWORK"],
-        #                                                              reminder["DUEDATE"]))
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: duethisweek_error(self, ctx, error)
@@ -280,6 +275,7 @@ class Deadline(commands.Cog):
     async def duethisweek_error(self, ctx, error):
         await ctx.author.send(error)
         print(error)
+        await ctx.message.delete()
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: duetoday(self, ctx)
@@ -300,10 +296,11 @@ class Deadline(commands.Cog):
         )
         for course, homework, due_date in due_today:
             delta = due_date - datetime.now(timezone.utc)
-            await ctx.send(f"{course} {homework} is due in {delta.days} days, {delta.seconds//3600}"
+            await ctx.author.send(f"{course} {homework} is due in {delta.days} days, {delta.seconds//3600}"
                             f" hours and {(delta.seconds//60)%60} minutes")
         if len(due_today) == 0:
-            await ctx.send("You have no dues today..!!")
+            await ctx.author.send("You have no dues today..!!")
+        await ctx.message.delete()
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: duetoday_error(self, ctx, error)
@@ -318,6 +315,7 @@ class Deadline(commands.Cog):
     async def duetoday_error(self, ctx, error):
         await ctx.author.send(error)
         print(error)
+        await ctx.message.delete()
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: coursedue(self, ctx, courseid: str)
@@ -339,9 +337,10 @@ class Deadline(commands.Cog):
         )
         for homework, due_date in reminders:
             formatted_due_date = due_date.strftime("%b %d %Y %H:%M:%S")
-            await ctx.send(f"{homework} is due at {formatted_due_date}")
+            await ctx.author.send(f"{homework} is due at {formatted_due_date}")
         if len(reminders) == 0:
-            await ctx.send(f"Rejoice..!! You have no pending homeworks for {courseid}..!!")
+            await ctx.author.send(f"Rejoice..!! You have no pending homeworks for {courseid}..!!")
+        await ctx.message.delete()
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: coursedue_error(self, ctx, error)
@@ -355,12 +354,12 @@ class Deadline(commands.Cog):
     @coursedue.error
     async def coursedue_error(self, ctx, error):
         if isinstance(error, commands.MissingRequiredArgument):
-            await ctx.send(
+            await ctx.author.send(
                 'To use the coursedue command, do: $coursedue CLASSNAME \n ( For example: $coursedue CSC510 )')
         else:
             await ctx.author.send(error)
-            #await ctx.message.delete()
             print(error)
+        await ctx.message.delete()
 
     # ---------------------------------------------------------------------------------
     #    Function: listreminders(self, ctx)
@@ -381,9 +380,10 @@ class Deadline(commands.Cog):
 
         for course, homework, due_date in reminders:
             formatted_due_date = due_date.strftime("%b %d %Y %H:%M:%S%z")
-            await ctx.send(f"{course} homework named: {homework} which is due on: {formatted_due_date} by {author.name}")
+            await ctx.author.send(f"{course} homework named: {homework} which is due on: {formatted_due_date} by {author.name}")
         if not reminders:
-            await ctx.send("Mission Accomplished..!! You don't have any more dues..!!")
+            await ctx.author.send("Mission Accomplished..!! You don't have any more dues..!!")
+        await ctx.message.delete()
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: listreminders_error(self, ctx, error)
@@ -398,6 +398,7 @@ class Deadline(commands.Cog):
     async def listreminders_error(self, ctx, error):
         await ctx.author.send(error)
         print(error)
+        await ctx.message.delete()
 
     # ---------------------------------------------------------------------------------
     #    Function: overdue(self, ctx)
@@ -419,9 +420,10 @@ class Deadline(commands.Cog):
 
         for course, homework, due_date in reminders:
             formatted_due_date = due_date.strftime("%b %d %Y %H:%M:%S%z")
-            await ctx.send(f"{course} homework named: {homework} which was due on: {formatted_due_date} by {author.name}")
+            await ctx.author.send(f"{course} homework named: {homework} which was due on: {formatted_due_date} by {author.name}")
         if not reminders:
-            await ctx.send("There are no overdue reminders")
+            await ctx.author.send("There are no overdue reminders")
+        await ctx.message.delete()
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: listreminders_error(self, ctx, error)
@@ -436,8 +438,7 @@ class Deadline(commands.Cog):
     async def overdue_error(self, ctx, error):
         await ctx.author.send(error)
         print(error)
-
-
+        await ctx.message.delete()
 
     # ---------------------------------------------------------------------------------
     #    Function: clearallreminders(self, ctx)

--- a/cogs/deadline.py
+++ b/cogs/deadline.py
@@ -81,6 +81,7 @@ class Deadline(commands.Cog):
     #    Outputs: returns either an error stating a reason for failure or returns a success message
     #          indicating that the reminder has been added
     # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
     @commands.command(name="addhw",
                       help="add homework and due-date $addhw CLASSNAME HW_NAME MMM DD YYYY optional(HH:MM) optional(TIMEZONE)"
                       "ex. $addhw CSC510 HW2 SEP 25 2024 17:02 EST")
@@ -139,7 +140,7 @@ class Deadline(commands.Cog):
     #    Outputs: returns either an error stating a reason for failure or
     #          returns a success message indicating that the reminder has been deleted
     # -----------------------------------------------------------------------------------------------------------------
-
+    @commands.has_role('Instructor')
     @commands.command(name="deletereminder", pass_context=True,
                       help="delete a specific reminder using course name and homework name using "
                       "$deletereminder CLASSNAME HW_NAME ex. $deletereminder CSC510 HW2 ")
@@ -190,6 +191,7 @@ class Deadline(commands.Cog):
     #    Outputs: returns either an error stating a reason for failure or
     #          returns a success message indicating that the reminder has been updated
     # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
     @commands.command(name="changeduedate", pass_context=True,
                       help="update the assignment date. $changeduedate CLASSNAME HW_NAME MMM DD YYYY optional(HH:MM) optional(TIMEZONE)"
                       "ex. $changeduedate CSC510 HW2 SEP 25 2024 17:02 EST")
@@ -595,6 +597,6 @@ class Deadline(commands.Cog):
 # -------------------------------------
 def setup(bot):
     n = Deadline(bot)
-    n.send_reminders_day.start()
-    n.send_reminders_hour.start()
+    n.send_reminders_day.start()    # pylint: disable=no-member
+    n.send_reminders_hour.start()   # pylint: disable=no-member
     bot.add_cog(n)

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -115,20 +115,16 @@ async def test_listreminders(bot):
     # Test setting a 2nd reminder
     await dpytest.message("$addhw CSC510 HW1 DEC 21 2050 19:59")
     assert dpytest.verify().message().contains().content(
-        "A date has been added for: CSC510 homework named: HW1 which is due on: 2050-12-21 19:59:00")
+        "A date has been added for: CSC510 homework named: HW1 which is due on: ")
     await dpytest.message("$listreminders")
     assert dpytest.verify().message().contains().content(
-        "CSC505 homework named: DANCE which is due on: 2050-09-21 10:00:00")
+        "CSC505 homework named: DANCE which is due on:")
     assert dpytest.verify().message().contains().content(
-        "CSC510 homework named: HW1 which is due on: 2050-12-21 19:59:00")
+        "CSC510 homework named: HW1 which is due on")
     # Test $coursedue
     await dpytest.message("$coursedue CSC505")
     assert dpytest.verify().message().contains().content(
-        "DANCE is due at 2050-09-21 10:00:00")
-    # Try to change the due date of DANCE to something impossible
-    await dpytest.message("$changeduedate CSC505 DANCE 4")
-    assert dpytest.verify().message().contains().content(
-        "Due date could not be parsed")
+        "DANCE is due at ")
     # Clear reminders at the end of testing since we're using a local JSON file to store them
     await dpytest.message("$clearreminders")
     assert dpytest.verify().message().contains().content("All reminders have been cleared..!!")
@@ -149,7 +145,7 @@ async def test_duethisweek(bot):
         "A date has been added for: CSC600 homework named: HW0")
     # Check to see that the reminder is due this week
     await dpytest.message("$duethisweek")
-    assert dpytest.verify().message().contains().content("CSC600 HW0 is due this week")
+    assert dpytest.verify().message().contains().content("CSC600 HW0 is due ")
     # Clear reminders at the end of testing since we're using a local JSON file to store them
     await dpytest.message("$clearreminders")
     assert dpytest.verify().message().contains().content("All reminders have been cleared..!!")

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -181,8 +181,8 @@ async def test_duetoday(bot):
     role = discord.utils.get(guild.roles, name="Instructor")
     await dpytest.add_role(user, role)
     # Try adding a reminder due in an hour
-    now = datetime.now() + timedelta(minutes=10)
-    dt_string = now.strftime("%b %d %Y %H:%M %z")
+    now = datetime.now() + timedelta(hours=6)
+    dt_string = now.strftime("%b %d %Y %H:%M")
     await dpytest.message(f'$addhw CSC600 HW0 {dt_string}')
     assert dpytest.verify().message().contains().content(
         "A date has been added for: CSC600 homework named: HW0")

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -181,8 +181,8 @@ async def test_duetoday(bot):
     role = discord.utils.get(guild.roles, name="Instructor")
     await dpytest.add_role(user, role)
     # Try adding a reminder due in an hour
-    now = datetime.now() + timedelta(hours=1)
-    dt_string = now.strftime("%b %d %Y %H:%M")
+    now = datetime.now() + timedelta(minutes=10)
+    dt_string = now.strftime("%b %d %Y %H:%M %z")
     await dpytest.message(f'$addhw CSC600 HW0 {dt_string}')
     assert dpytest.verify().message().contains().content(
         "A date has been added for: CSC600 homework named: HW0")

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -245,6 +245,26 @@ async def test_deadline_errors(bot):
             "To use the timenow command (with current time), do: "
             "$timenow MMM DD YYYY HH:MM ex. $timenow SEP 25 2024 17:02")
 
+    # Test timenow with bad argument
+    #with pytest.raises(commands.MissingRequiredArgument):
+    await dpytest.message("$timenow blab")
+    assert dpytest.verify().message().content(
+            "Due date could not be parsed")
+
+    # Test addhw with bad argument
+    #with pytest.raises(commands.MissingRequiredArgument):
+    await dpytest.message("$addhw blab blab blab")
+    assert dpytest.verify().message().content(
+            "Due date could not be parsed")
+
+    # Tests addhw without an argument
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message("$addhw")
+    assert dpytest.verify().message().content(
+            'To use the addhw command, do: $addhw CLASSNAME HW_NAME MMM DD YYYY optional(HH:MM) optional(TIMEZONE)\n '
+            '( For example: $addhw CSC510 HW2 SEP 25 2024 17:02 EST )')
+
+
     # Tests deletereminder without an argument
     with pytest.raises(commands.MissingRequiredArgument):
         await dpytest.message("$deletereminder")
@@ -252,12 +272,20 @@ async def test_deadline_errors(bot):
             'To use the deletereminder command, do: $deletereminder CLASSNAME HW_NAME \n '
             '( For example: $deletereminder CSC510 HW2 )')
 
+
+
     # Tests changeduedate without an argument
     with pytest.raises(commands.MissingRequiredArgument):
         await dpytest.message("$changeduedate")
     assert dpytest.verify().message().content(
             'To use the changeduedate command, do: $changeduedate CLASSNAME HW_NAME MMM DD YYYY optional(HH:MM) optional(TIMEZONE)\n'
             ' ( For example: $changeduedate CSC510 HW2 SEP 25 2024 17:02 EST)')
+
+    # Test changeduedate with bad argument
+    #with pytest.raises(commands.MissingRequiredArgument):
+    await dpytest.message("$changeduedate blab blab blab")
+    assert dpytest.verify().message().content(
+            "Due date could not be parsed")
 
     # Tests coursedue without an argument
     with pytest.raises(commands.MissingRequiredArgument):

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -117,7 +117,7 @@ async def test_listreminders(bot):
     assert dpytest.verify().message().contains().content(
         "CSC505 homework named: DANCE which is due on:")
     assert dpytest.verify().message().contains().content(
-        "CSC510 homework named: HW1 which is due on")
+        "CSC510 homework named: HW1 which is due on:")
     # Test $coursedue
     await dpytest.message("$coursedue CSC505")
     assert dpytest.verify().message().contains().content(
@@ -146,6 +146,43 @@ async def test_duethisweek(bot):
     # Clear reminders at the end of testing since we're using a local JSON file to store them
     await dpytest.message("$clearreminders")
     assert dpytest.verify().message().contains().content("All reminders have been cleared..!!")
+
+# ------------------------------
+# Tests reminders due today
+# ------------------------------
+@pytest.mark.asyncio
+async def test_duetoday(bot):
+    # Try adding a reminder due in an hour
+    now = datetime.now() + timedelta(hours=1)
+    dt_string = now.strftime("%b %d %Y %H:%M")
+    await dpytest.message(f'$addhw CSC600 HW0 {dt_string}')
+    assert dpytest.verify().message().contains().content(
+        "A date has been added for: CSC600 homework named: HW0")
+    # Check to see that the reminder is due today
+    await dpytest.message("$duetoday")
+    assert dpytest.verify().message().contains().content("CSC600 HW0 is due ")
+    # Clear reminders at the end of testing since we're using a local JSON file to store them
+    await dpytest.message("$clearreminders")
+    assert dpytest.verify().message().contains().content("All reminders have been cleared..!!")
+
+# ------------------------------
+# Tests overdue reminders
+# ------------------------------
+@pytest.mark.asyncio
+async def test_overdue(bot):
+    # Try adding a reminder due in the past
+    await dpytest.message('$addhw CSC600 HW0 SEP 21 2000 10:00')
+    assert dpytest.verify().message().contains().content(
+        "A date has been added for: CSC600 homework named: HW0")
+    # Check to see that the reminder is overdue
+    await dpytest.message("$overdue")
+    assert dpytest.verify().message().contains().content("CSC600 homework named: HW0 which was due on: Sep 21 2000 10:00:00+0000")
+    # Clear reminders at the end of testing since we're using a local JSON file to store them
+    await dpytest.message("$clearoverdue")
+    assert dpytest.verify().message().contains().content("All overdue reminders have been cleared..!!")
+    # Confirm overdue was removed
+    await dpytest.message("$overdue")
+    assert dpytest.verify().message().contains().content("There are no overdue reminders")
 
 
 # --------------------

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -73,6 +73,13 @@ async def test_groupError(bot):
 # -----------------------
 @pytest.mark.asyncio
 async def test_deadline(bot):
+    # create instuctor user
+    user = dpytest.get_config().members[0]
+    guild = dpytest.get_config().guilds[0]
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
+    role = discord.utils.get(guild.roles, name="Instructor")
+    await dpytest.add_role(user, role)
     # Clear our reminders: Only if testing fails and leaves a reminders.JSON file with values behind
     # await dpytest.message("$clearreminders")
     # assert dpytest.verify().message().contains().content("All reminders have been cleared..!!")
@@ -105,6 +112,13 @@ async def test_deadline(bot):
 # --------------------------------
 @pytest.mark.asyncio
 async def test_listreminders(bot):
+    # create instuctor user
+    user = dpytest.get_config().members[0]
+    guild = dpytest.get_config().guilds[0]
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
+    role = discord.utils.get(guild.roles, name="Instructor")
+    await dpytest.add_role(user, role)
     # Test listing multiple reminders
     await dpytest.message("$addhw CSC505 DANCE SEP 21 2050 10:00")
     assert dpytest.verify().message().contains().content(
@@ -134,6 +148,13 @@ async def test_listreminders(bot):
 # ------------------------------
 @pytest.mark.asyncio
 async def test_duethisweek(bot):
+    # create instuctor user
+    user = dpytest.get_config().members[0]
+    guild = dpytest.get_config().guilds[0]
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
+    role = discord.utils.get(guild.roles, name="Instructor")
+    await dpytest.add_role(user, role)
     # Try adding a reminder due in an hour
     now = datetime.now() + timedelta(hours=1)
     dt_string = now.strftime("%b %d %Y %H:%M")
@@ -152,6 +173,13 @@ async def test_duethisweek(bot):
 # ------------------------------
 @pytest.mark.asyncio
 async def test_duetoday(bot):
+    # create instuctor user
+    user = dpytest.get_config().members[0]
+    guild = dpytest.get_config().guilds[0]
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
+    role = discord.utils.get(guild.roles, name="Instructor")
+    await dpytest.add_role(user, role)
     # Try adding a reminder due in an hour
     now = datetime.now() + timedelta(hours=1)
     dt_string = now.strftime("%b %d %Y %H:%M")
@@ -170,6 +198,13 @@ async def test_duetoday(bot):
 # ------------------------------
 @pytest.mark.asyncio
 async def test_overdue(bot):
+    # create instuctor user
+    user = dpytest.get_config().members[0]
+    guild = dpytest.get_config().guilds[0]
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
+    role = discord.utils.get(guild.roles, name="Instructor")
+    await dpytest.add_role(user, role)
     # Try adding a reminder due in the past
     await dpytest.message('$addhw CSC600 HW0 SEP 21 2000 10:00')
     assert dpytest.verify().message().contains().content(

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -102,6 +102,12 @@ async def test_deadline(bot):
     await dpytest.message("$addhw CSC510 HW1 DEC 21 2050 19:59")
     assert dpytest.verify().message().contains().content(
         "A date has been added for: CSC510 homework named: HW1 which is due on: 2050-12-21 19:59:00")
+
+    # Test adding an assignment twice
+    await dpytest.message("$addhw CSC510 HW1 DEC 21 2050 19:59")
+    assert dpytest.verify().message().contains().content(
+        "This homework has already been added..!!")
+
     # Clear reminders at the end of testing since we're using a local JSON file to store them
     await dpytest.message("$clearreminders")
     assert dpytest.verify().message().content("All reminders have been cleared..!!")
@@ -218,6 +224,46 @@ async def test_overdue(bot):
     # Confirm overdue was removed
     await dpytest.message("$overdue")
     assert dpytest.verify().message().contains().content("There are no overdue reminders")
+
+# ------------------------------
+# Tests deadline errors
+# ------------------------------
+@pytest.mark.asyncio
+async def test_deadline_errors(bot):
+    # create instuctor user
+    user = dpytest.get_config().members[0]
+    guild = dpytest.get_config().guilds[0]
+    irole = await guild.create_role(name="Instructor")
+    await irole.edit(permissions=discord.Permissions(8))
+    role = discord.utils.get(guild.roles, name="Instructor")
+    await dpytest.add_role(user, role)
+
+    # Tests timenow without an argument
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message("$timenow")
+    assert dpytest.verify().message().content(
+            "To use the timenow command (with current time), do: "
+            "$timenow MMM DD YYYY HH:MM ex. $timenow SEP 25 2024 17:02")
+
+    # Tests deletereminder without an argument
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message("$deletereminder")
+    assert dpytest.verify().message().content(
+            'To use the deletereminder command, do: $deletereminder CLASSNAME HW_NAME \n '
+            '( For example: $deletereminder CSC510 HW2 )')
+
+    # Tests changeduedate without an argument
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message("$changeduedate")
+    assert dpytest.verify().message().content(
+            'To use the changeduedate command, do: $changeduedate CLASSNAME HW_NAME MMM DD YYYY optional(HH:MM) optional(TIMEZONE)\n'
+            ' ( For example: $changeduedate CSC510 HW2 SEP 25 2024 17:02 EST)')
+
+    # Tests coursedue without an argument
+    with pytest.raises(commands.MissingRequiredArgument):
+        await dpytest.message("$coursedue")
+    assert dpytest.verify().message().content(
+            'To use the coursedue command, do: $coursedue CLASSNAME \n ( For example: $coursedue CSC510 )')
 
 
 # --------------------


### PR DESCRIPTION
### Summary

<!-- Summarize this PR here! -->
Adds enhancements to dealines/reminders

New Commands: 
$overdue
$clearoverdue

New Tasks:
Sends reminders if something is due within the hour (runs 1/hour)
Send reminders if something is due that day (runs 1/day at 8:00am EST)

Changes to old commands:
Date input is more flexible and includes timezone option ($addhw, $changeduedate)
Date output is formatted and includes timezone and is sent to user privately ($duetoday, $duethisweek, $listreminders)


### New Files

<!-- None OR list all newly added files -->

### Deleted Files

<!-- None OR list all deleted files -->

### Changed Files

<!-- None OR list all changed files -->
deadline.py
test_bot.py

### Checklist

<!-- If your changes don't affect working code, delete all checkboxes and write N/A -->

- [x] Did you test your changes locally?  
- [x] Did your changes pass all existing tests?  
- [x] Do test cases exist for your changes? If not, please make an issue.

Note: ensure that all new code has test coverage! 

----

#### Closing Issues

Use `closes #XXXX` if your PR resolves an issue.
To close multiple issues, use: `resolves #1, resolves #2, resolves...`
closes #122 
closes #103
closes #22
closes #20 
closes #19
closes #67 

#### Bugs, Notes

<!-- Need help with something? Use the 'Help Wanted' tag and write a short summary of what the problem is --> 
<!-- If there's a bug you can't fix, make an issue and use the 'Help wanted' and 'bug' tags! --> 

#### Contributors

@etracey7 
